### PR TITLE
use hls stream playlist including audio stream for playback

### DIFF
--- a/default.py
+++ b/default.py
@@ -142,11 +142,7 @@ def resolve(title, url, media):
 
                 else:
                     streamURL = streamURL[0].replace('\/','/')
-                    stream = parse_m3u8(streamURL)
-                    if stream:
-                        streamURL = streamURL.rsplit('/', 1)[0] + '/' + stream
-                    else:
-                        streamURL = None
+                    
             else:
                 streamURL = None
 


### PR DESCRIPTION
Fixing issue #1 

Tested on Linux and Android, live streams have sound now. Audio delay might need to be adjusted during playback.